### PR TITLE
[New Feature] Added support for changing map and keeping the same mod on extension.

### DIFF
--- a/addons/amxmodx/configs/multimod_manager/configs.json
+++ b/addons/amxmodx/configs/multimod_manager/configs.json
@@ -75,6 +75,10 @@
 				// "change_map_type": 1 (The map will change at the end of the round)
 				// "change_map_type": 2 (Allows to play 1 more round and then changes the map)
 
+			"extend_current_mode_changes_map": false,
+				// false = Extends the map by the amount set by the cvar.
+				// true = Starts a map vote for the current mod.
+
 
 			"cvars":
 			[
@@ -112,6 +116,7 @@
 			"mod_tag": "dm",
 			"mapsfile":"deathmatch_maps.ini",
 			"change_map_type": 1,
+			"extend_current_mode_changes_map": false,
 			"cvars":
 			[
 				"sv_gravity 900", "sv_alltalk 1"
@@ -137,6 +142,7 @@
 			"mod_tag": "fr",
 			"mapsfile":"fruta_maps.ini",
 			"change_map_type": 1,
+			"extend_current_mode_changes_map": false,
 			"cvars":
 			[
 				"sv_gravity 900", "sv_alltalk 1"
@@ -162,6 +168,7 @@
 			"mod_tag": "zp",
 			"mapsfile":"zp_maps.ini",
 			"change_map_type": 1,
+			"extend_current_mode_changes_map": false,
 			"cvars":
 			[
 				"sv_gravity 900", "sv_alltalk 1"
@@ -187,6 +194,7 @@
 			"mod_tag": "pb",
 			"mapsfile":"paintball_maps.ini",
 			"change_map_type": 1,
+			"extend_current_mode_changes_map": false,
 			"cvars":
 			[
 				"sv_gravity 900", "sv_alltalk 1"
@@ -212,6 +220,7 @@
 			"mod_tag": "hns",
 			"mapsfile":"hns_maps.ini",
 			"change_map_type": 1,
+			"extend_current_mode_changes_map": false,
 			"cvars":
 			[
 				"sv_gravity 900", "sv_alltalk 1"
@@ -237,6 +246,7 @@
 			"mod_tag": "sf",
 			"mapsfile":"surf_maps.ini",
 			"change_map_type": 1,
+			"extend_current_mode_changes_map": false,
 			"cvars":
 			[
 				"sv_gravity 900", "sv_alltalk 1"

--- a/addons/amxmodx/scripting/include/mm_incs/cvars.inc
+++ b/addons/amxmodx/scripting/include/mm_incs/cvars.inc
@@ -24,4 +24,6 @@ Cvars_Init()
 
 	set_pcvar_string(create_cvar("multimod_manager_version", PLUGIN_VERSION, FCVAR_SERVER | FCVAR_SPONLY), PLUGIN_VERSION);
 	set_pcvar_string(create_cvar("multimod_manager_url", PLUGIN_URL, FCVAR_SERVER | FCVAR_SPONLY), PLUGIN_URL);
+
+	bind_pcvar_string((g_pCvar_mm_extended_mod = create_cvar("mm_extended_mod", "")),g_bCvar_mm_extended_mod,charsmax(g_bCvar_mm_extended_mod));
 }

--- a/addons/amxmodx/scripting/include/mm_incs/defines.inc
+++ b/addons/amxmodx/scripting/include/mm_incs/defines.inc
@@ -81,6 +81,7 @@ enum _:ArrayMods_e
 	ModName[MAX_MODNAME_LENGTH],
 	ModTag[MAX_MODNAME_LENGTH],
 	ChangeMap_e:ChangeMapType,
+	bool:ExtendCurrentModeChangesMap,
 	Array:Maps,
 	Array:Cvars,
 	Array:Plugins,

--- a/addons/amxmodx/scripting/include/mm_incs/global.inc
+++ b/addons/amxmodx/scripting/include/mm_incs/global.inc
@@ -61,6 +61,9 @@ new Float:g_bCvar_mp_chattime, g_pCvar_mp_chattime;
 new g_bCvar_mp_timelimit;
 new g_bCvar_amx_multimod_voice;
 
+// Mod Extension Cvars
+new g_pCvar_mm_extended_mod;
+new g_bCvar_mm_extended_mod[MAX_MODNAME_LENGTH];
 
 /* ===========================================================================
 *                 [ ADMIN COMMANDS ]

--- a/addons/amxmodx/scripting/include/mm_incs/modchooser.inc
+++ b/addons/amxmodx/scripting/include/mm_incs/modchooser.inc
@@ -97,7 +97,7 @@ public OnTask_VoteNextMod()
 		menu_additem(g_Menu_ModChooser, fmt("\w%s%s", aMods[ModName], (g_iModVoteNum == (iMaxMods-1)) ? "^n" : ""), fmt("%d", g_iModVoteNum));
 	}
 
-	if(IsAvailableExtendMap())
+	if(IsAvailableExtendMap() && !UTIL_CurrentModAlreadyExtended())
 	{
 		if(g_bIsRockTheVote)
 			menu_additem(g_Menu_ModChooser, fmt("\w%L^n", LANG_PLAYER, "MM_M_EXTEND_CURRENT_MODE_RTV", g_szCurrentMod), fmt("%d", OPTION_EXTEND_MOD));
@@ -301,6 +301,8 @@ public OnTaskCheckVoteMod()
 					Nominations_ResetAllData();
 
 					g_bSelectedNextMod = true;
+
+					set_pcvar_string(g_pCvar_mm_extended_mod, g_szCurrentMod);
 
 					MapChooser_InitNextVoteMap(40);
 				}

--- a/addons/amxmodx/scripting/include/mm_incs/modchooser.inc
+++ b/addons/amxmodx/scripting/include/mm_incs/modchooser.inc
@@ -288,13 +288,32 @@ public OnTaskCheckVoteMod()
 			}
 			else
 			{
-				ExtendTimeleft(g_bCvar_amx_extendmap_step);
-				client_print_color(0, print_team_blue, "%s^1 %L", g_GlobalConfigs[ChatPrefix], LANG_PLAYER, "MM_MOD_CHO_FIN_EXT", g_bCvar_amx_extendmap_step, iResult, g_iVoteModCount, UTIL_GetPercent(iResult, g_iVoteModCount));
+				ArrayGetArray(g_GlobalConfigs[Mods], g_iCurrentMod, aData);
 
-				ModChooser_ResetAllData();
-				Nominations_ResetAllData();
+				if(aData[ExtendCurrentModeChangesMap])
+				{
+					g_iNextSelectMod = g_iCurrentMod;
+					MultiMod_SetNextMod(g_iNextSelectMod);
+
+					client_print_color(0, print_team_blue, "%s^1 El modo actual continuara. Comenzando votación para cambio de mapa.", g_GlobalConfigs[ChatPrefix]);
+
+					ModChooser_ResetAllData();
+					Nominations_ResetAllData();
+
+					g_bSelectedNextMod = true;
+
+					MapChooser_InitNextVoteMap(40);
+				}
+				else
+				{
+					ExtendTimeleft(g_bCvar_amx_extendmap_step);
+
+					client_print_color(0, print_team_blue, "%s^1 %L", g_GlobalConfigs[ChatPrefix], LANG_PLAYER, "MM_MOD_CHO_FIN_EXT", g_bCvar_amx_extendmap_step, iResult, g_iVoteModCount, UTIL_GetPercent(iResult, g_iVoteModCount));
+
+					ModChooser_ResetAllData();
+					Nominations_ResetAllData();
+				}
 			}
-			
 			return;
 		}
 

--- a/addons/amxmodx/scripting/include/mm_incs/modchooser.inc
+++ b/addons/amxmodx/scripting/include/mm_incs/modchooser.inc
@@ -97,7 +97,7 @@ public OnTask_VoteNextMod()
 		menu_additem(g_Menu_ModChooser, fmt("\w%s%s", aMods[ModName], (g_iModVoteNum == (iMaxMods-1)) ? "^n" : ""), fmt("%d", g_iModVoteNum));
 	}
 
-	if(IsAvailableExtendMap())
+	if(IsAvailableExtendMap() && !(iRecentMods && Recent_IsRecentMod(g_szCurrentMod)))
 	{
 		if(g_bIsRockTheVote)
 			menu_additem(g_Menu_ModChooser, fmt("\w%L^n", LANG_PLAYER, "MM_M_EXTEND_CURRENT_MODE_RTV", g_szCurrentMod), fmt("%d", OPTION_EXTEND_MOD));

--- a/addons/amxmodx/scripting/include/mm_incs/modchooser.inc
+++ b/addons/amxmodx/scripting/include/mm_incs/modchooser.inc
@@ -97,7 +97,7 @@ public OnTask_VoteNextMod()
 		menu_additem(g_Menu_ModChooser, fmt("\w%s%s", aMods[ModName], (g_iModVoteNum == (iMaxMods-1)) ? "^n" : ""), fmt("%d", g_iModVoteNum));
 	}
 
-	if(IsAvailableExtendMap() && !(iRecentMods && Recent_IsRecentMod(g_szCurrentMod)))
+	if(IsAvailableExtendMap())
 	{
 		if(g_bIsRockTheVote)
 			menu_additem(g_Menu_ModChooser, fmt("\w%L^n", LANG_PLAYER, "MM_M_EXTEND_CURRENT_MODE_RTV", g_szCurrentMod), fmt("%d", OPTION_EXTEND_MOD));

--- a/addons/amxmodx/scripting/include/mm_incs/utils.inc
+++ b/addons/amxmodx/scripting/include/mm_incs/utils.inc
@@ -165,3 +165,11 @@ stock UTIL_SimpleSortVotes(iPos[], iNum[], const iSize)
 		}
 	}
 }
+
+stock bool:UTIL_CurrentModAlreadyExtended()
+{
+	if (equali(g_bCvar_mm_extended_mod, g_szCurrentMod))
+		return true;
+
+	return false;
+}

--- a/addons/amxmodx/scripting/multimod_manager.sma
+++ b/addons/amxmodx/scripting/multimod_manager.sma
@@ -279,6 +279,8 @@ MultiMod_Init()
 
 			aMod[ChangeMapType] = ChangeMap_e:json_object_get_number(jArrayValue, "change_map_type");
 
+			aMod[ExtendCurrentModeChangesMap] = json_object_get_bool(jArrayValue, "extend_current_mode_changes_map");
+
 			aMod[Maps] = ArrayCreate(MAX_MAPNAME_LENGTH);
 			json_object_get_string(jArrayValue, "mapsfile", szMapFile, charsmax(szMapFile));
 			format(szMapFile, PLATFORM_MAX_PATH-1, "%s/%s/%s/%s", szConfigDir, MM_CONFIG_FOLDER, MM_MAPSFILE_FOLDER, szMapFile);

--- a/addons/amxmodx/scripting/multimod_manager.sma
+++ b/addons/amxmodx/scripting/multimod_manager.sma
@@ -836,6 +836,12 @@ MultiMod_SetNextMod(const iNextMod)
 	new aDataNextMod[ArrayMods_e];
 	ArrayGetArray(g_GlobalConfigs[Mods], iNextMod, aDataNextMod);
 
+	// Reiniciamos la CVAR si el siguiente modo no es el mismo.
+	if (!equali(aDataNextMod[ModName], g_szCurrentMod))
+	{
+		set_pcvar_string(g_pCvar_mm_extended_mod, "");
+	}
+
 	new szFileName[PLATFORM_MAX_PATH];
 	new iLen = get_configsdir(szFileName, charsmax(szFileName));
 	formatex(szFileName[iLen], charsmax(szFileName) - iLen, "/%s", MM_PLUGINS_FILENAME);


### PR DESCRIPTION
Title. It basically adds the option (per mod) to allow extension of time (default) or extension by changing the current map.

It also has a system managed by a CVAR that gets filled with the mod ID when the mod was extended with a map change and a reset when a different mod is selected.